### PR TITLE
docs: 收口首页 Ant 提及为一处 honest 致敬

### DIFF
--- a/packages/docs/index.md
+++ b/packages/docs/index.md
@@ -3,7 +3,7 @@ layout: home
 hero:
   name: ccui
   text: Vue 3 组件库
-  tagline: 视觉对齐 Ant Design v6.3.7，开箱即用的 Vue 3 + TypeScript 组件库
+  tagline: 开箱即用的 Vue 3 + TypeScript 组件库，视觉设计致敬 Ant Design
   image:
     src: /logo.svg
     alt: cc ui
@@ -24,7 +24,7 @@ features:
 
   - icon: 🧩
     title: 84 个组件
-    details: 通用 / 布局 / 导航 / 数据录入 / 数据展示 / 反馈 / 其他 七大类 84 个组件，致敬 Ant Design 视觉风格。
+    details: 通用 / 布局 / 导航 / 数据录入 / 数据展示 / 反馈 / 其他 七大类 84 个组件，覆盖中后台常见业务场景。
 
   - icon: 🛠️
     title: TypeScript 优先


### PR DESCRIPTION
去掉 tagline 的精确版本号 v6.3.7、「对齐」软化为「致敬」；特性卡改为不点名 ant 的中性业务描述。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated homepage tagline to emphasize Vue 3 + TypeScript out-of-the-box support.
  * Revised component library description to highlight coverage of common business scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->